### PR TITLE
Check that AZs are balanced after an IG is scaled

### DIFF
--- a/kube-gcp-updater
+++ b/kube-gcp-updater
@@ -267,6 +267,23 @@ cycle_nodes() {
   done
   set -e
 
+  # check that nodes are balanced across three AZs
+  local nodes_per_zone
+  nodes_per_zone=$(kubectl --context "${kube_context}" get nodes -lrole="${role}" --no-headers -ocustom-columns=':.metadata.labels.failure-domain\.beta\.kubernetes\.io\/zone' |\
+      sort |\
+      uniq -c)
+  local npz
+  readarray -t npz < <(echo "${nodes_per_zone}" | awk '{print $1}')
+  if [ "${#npz[@]}" -ne 3 ]; then
+      log "Expected nodes across three zones. Node distribution:\n$nodes_per_zone\nCannot proceed, exiting"
+      exit 1
+  fi
+  # shellcheck disable=SC2252
+  if [ "${npz[0]}" != "${npz[1]}" ] || [ "${npz[0]}" != "${npz[2]}" ] || [ "${npz[1]}" != "${npz[2]}" ]; then
+      log "Nodes are not perfectly balanced across zones. Node distribution:\n$nodes_per_zone\nCannot proceed, exiting"
+      exit 1
+  fi
+
   # - drain labelled nodes (sequentially)
   local old_nodes=$(retry kubectl --context="${kube_context}" get nodes -l role="${role}",retiring="${retire_time}" -o json |\
     jq -r '.items[].metadata.name')


### PR DESCRIPTION
Although it is not clear whether a GCP Instance Group can end up with
nodes unevenly spread across AZs, it's worth adding this check to
prevent a problematic update. Standard PDs are not replicated by default
and can still cause scheduling issues in case of unbalanced AZs.