### PR TITLE
Wait for controller-manager to populate topology labels

### DIFF
--- a/kube-gcp-updater
+++ b/kube-gcp-updater
@@ -293,20 +293,25 @@ cycle_nodes() {
   done
   set -e
 
+  # Check that failure domain labels are populated by the respective controller
+  while [[ $(kubectl --context "${kube_context}" get nodes -lrole="master" --no-headers -ocustom-columns=':.metadata.labels.topology\.kubernetes\.io\/zone' | grep "<none>" | wc -l) -gt 0 ]]; do
+    echo "Waiting for cloud controller to populate topology.kubernetes.io/zone label on all nodes";
+    sleep 1;
+  done
   # check that nodes are balanced across three AZs
   local nodes_per_zone
-  nodes_per_zone=$(kubectl --context "${kube_context}" get nodes -lrole="${role}" --no-headers -ocustom-columns=':.metadata.labels.failure-domain\.beta\.kubernetes\.io\/zone' |\
+  nodes_per_zone=$(kubectl --context "${kube_context}" get nodes -lrole="${role}" --no-headers -ocustom-columns=':.metadata.labels.topology\.kubernetes\.io\/zone' |\
       sort |\
       uniq -c)
   local npz
   readarray -t npz < <(echo "${nodes_per_zone}" | awk '{print $1}')
   if [ "${#npz[@]}" -ne 3 ]; then
-      log "Expected nodes across three zones. Node distribution:\n$nodes_per_zone\nCannot proceed, exiting"
+      echo "Expected nodes across three zones. Node distribution:\n$nodes_per_zone\nCannot proceed, exiting"
       exit 1
   fi
   # shellcheck disable=SC2252
   if [ "${npz[0]}" != "${npz[1]}" ] || [ "${npz[0]}" != "${npz[2]}" ] || [ "${npz[1]}" != "${npz[2]}" ]; then
-      log "Nodes are not perfectly balanced across zones. Node distribution:\n$nodes_per_zone\nCannot proceed, exiting"
+      echo "Nodes are not perfectly balanced across zones. Node distribution:\n$nodes_per_zone\nCannot proceed, exiting"
       exit 1
   fi
 


### PR DESCRIPTION
If the script tries to check whether nodes are balanced across zones before the cloud-controller manager is up and has labelled nodes then the script will fail. This surfaced since cloud-controller for gcp starts after the node is marked as control-plane and we need to wait a bit before the topology labels are present on fresh nodes